### PR TITLE
Updated node to 20 version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
 
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 
 


### PR DESCRIPTION
Node version updated due to https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Fixes #361 