### PR TITLE
Update Action to build source maps alongside compiled CSS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Sass Build'
+name: 'Sass Build with Maps'
 description: 'GitHub Action JavaScript wrapper runs Sass build with provided Inputs'
 
 
@@ -31,7 +31,7 @@ inputs:
 
   indentWidth:
     description: 'Integer, of tabs/spaces used to indent, eg. `1`'
-    default: 2
+    default: '2'
     required: false
 
   linefeed:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Sass Build with Maps'
+name: 'Sass Build'
 description: 'GitHub Action JavaScript wrapper runs Sass build with provided Inputs'
 
 

--- a/index.js
+++ b/index.js
@@ -107,6 +107,17 @@ if (sourceMap === 'true' || sourceMap === 'false') {
 }
 
 
+function saveFile(fileContent, filePath) {
+	fs.writeFile(filePath, fileContent, (err) => {
+		if (err) {
+			throw err;
+		} else {
+			console.log(`Wrote file -> ${filePath}`);
+		}
+	});
+}
+
+
 /**
  * Compiles CSS and write it to file path
  * @param {string} source_file - Path to SCSS or SASS file to parse
@@ -148,13 +159,8 @@ function build_CSS(source_file, destination_file) {
       console.warn(warnning_message.join('\n'));
     }
 
-    fs.writeFile(destination_file, sass_result.css, (err) => {
-      if (err) {
-        throw err;
-      } else {
-        console.log(`Wrote file -> ${destination_file}`);
-      }
-    });
+		// write CSS file
+		saveFile(destination_file, sass_result.css);
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -101,22 +101,22 @@ if (includePaths !== undefined && includePaths !== '') {
 }
 
 // 'sourceMap'          // May be boolean or string, see https://sass-lang.com/documentation/js-api#sourcemap
-// 'outFile'						// String, does not write but is useful in combination with 'sourceMap'
+// 'outFile'            // String, does not write but is useful in combination with 'sourceMap'
 const sourceMap = get_gha_input('sourceMap');
 const outFile = get_gha_input('outFile');
 
 // if the sourceMap is passed as a boolean in a string, get its boolean value and the name of the outfile
 if (sourceMap === 'true' || sourceMap === 'false') {
-	generate_source_map = (sourceMap === 'true');
+  generate_source_map = (sourceMap === 'true');
   // if outFile isn't given, set it to the name of the main CSS output file (ex: 'main.css') and append '.map'
-	source_map_filename = outFile !== undefined ? `${outFile}` : `${path.basename(destination.join())}.map`;
+  source_map_filename = outFile !== undefined ? `${outFile}` : `${path.basename(destination.join())}.map`;
   render_options['sourceMap'] = (sourceMap === 'true');
 
 // if sourceMap is passed as a string itself, i.e. a path, consider it true and set the outfile 
 // name to its sourceMap's value
 } else if (sourceMap !== undefined && sourceMap !== '') {
-	generate_source_map = true;
-	source_map_filename = sourceMap;
+  generate_source_map = true;
+  source_map_filename = sourceMap;
   render_options['sourceMap'] = sourceMap;
 }
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ const boolean_gha_input_names = [
   'sourceMapContents',  // Boolean, when `true` embeds contents of Sass files that contributed to compiled CSS
   'sourceMapEmbed',     // Boolean, when `true` embeds source map within compiled CSS
 ];
+var generate_source_map;
+var source_map_filename;
 
 
 const integer_gha_input_names = [
@@ -99,10 +101,16 @@ if (includePaths !== undefined && includePaths !== '') {
 }
 
 // 'sourceMap'          // May be boolean or string, see https://sass-lang.com/documentation/js-api#sourcemap
+// 'outFile'						// String, does not write but is useful in combination with 'sourceMap'
 const sourceMap = get_gha_input('sourceMap');
+const outFile = get_gha_input('outFile');
 if (sourceMap === 'true' || sourceMap === 'false') {
+	generate_source_map = (sourceMap === 'true');
+	source_map_filename = `${outFile}.map`
   render_options['sourceMap'] = (sourceMap === 'true');
 } else if (sourceMap !== undefined && sourceMap !== '') {
+	generate_source_map = true;
+	source_map_filename = sourceMap;
   render_options['sourceMap'] = sourceMap;
 }
 
@@ -161,6 +169,11 @@ function build_CSS(source_file, destination_file) {
 
 		// write CSS file
 		saveFile(destination_file, sass_result.css);
+
+		// write map file, if desired
+		if (generate_source_map == true) {
+			saveFile(source_map_filename, sass_result.map)
+		}
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ if (sourceMap === 'true' || sourceMap === 'false') {
 }
 
 
-function saveFile(fileContent, filePath) {
+function saveFile(filePath, fileContent) {
 	fs.writeFile(filePath, fileContent, (err) => {
 		if (err) {
 			throw err;

--- a/index.js
+++ b/index.js
@@ -172,7 +172,8 @@ function build_CSS(source_file, destination_file) {
 
 		// write map file, if desired
 		if (generate_source_map == true) {
-			saveFile(source_map_filename, sass_result.map)
+			const source_map_filePath = `${path.dirname(destination_file)}/${source_map_filename}`
+			saveFile(source_map_filePath, sass_result.map)
 		}
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sass-build-with-maps",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "sass": "^1.71.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sass-build-with-maps",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "AGPL-3.0",
       "dependencies": {
         "sass": "^1.71.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "sass-build",
-  "version": "0.6.0",
+  "name": "sass-build-with-maps",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sass-build",
-      "version": "0.6.0",
+      "name": "sass-build-with-maps",
+      "version": "0.7.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "sass": "^1.71.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "sass-build-with-maps",
-  "version": "0.7.3",
+  "name": "sass-build",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sass-build-with-maps",
-      "version": "0.7.3",
+      "name": "sass-build",
+      "version": "0.6.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "sass": "^1.71.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sass-build-with-maps",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "sass": "^1.71.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.4",
+  "version": "0.6.1",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {
-    "test": "node index.js"
+    "test": "node index.js",
+    "test-compile": "INPUT_SOURCE=test/main.sass INPUT_DESTINATION=test/main.css node index.js",
+    "test-sourcemap-auto": "INPUT_SOURCE=test/main.sass INPUT_DESTINATION=test/main.css INPUT_SOURCEMAP=true node index.js",
+    "test-sourcemap-manual": "INPUT_SOURCE=test/main.sass INPUT_DESTINATION=test/main.css INPUT_SOURCEMAP=true INPUT_OUTFILE=manual.css.map node index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sass-build-with-maps",
+  "name": "sass-build",
   "version": "0.6.1",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.8.0",
+  "version": "0.7.4",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sass-build-with-maps",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sass-build",
-  "version": "0.6.0",
-  "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs",
+  "name": "sass-build-with-maps",
+  "version": "0.7.0",
+  "description": "GitHub Action JavaScript wrapper runs Sass build with provided Inputs, exporting Map files when desired.",
   "main": "index.js",
   "scripts": {
     "test": "node index.js"


### PR DESCRIPTION
I know it's been a bit (sorry about that!), but I finally got this working and finished up. This Action now generates source maps when requested, as expected. It will automatically generate an output file name based on the main output file if not given. 

**Notes**

- New tests were added for testing both mapless and mapfull (?) compilation.
- The version was bumped to v0.6.1 to reflect a bugfix update.

**Feature Progress**

- [x] Fixes #396  

------

**Mentions**

Thanks to @S0AndS0 for pointing out how to run tests locally. I'm new to the whole world of Actions, so I appreciate it!
